### PR TITLE
Add GPU same-map interpolation for CUDACoefficient

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -21,6 +21,8 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 # Do not enable compler-specific extensions
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+enable_language(CUDA)
+set(CMAKE_CUDA_FLAGS " -lineinfo")
 # ------------------------------------------------------------------------------
 # Get GIT changeset, if available
 find_program(GIT_FOUND git)

--- a/cpp/cudolfinx/CMakeLists.txt
+++ b/cpp/cudolfinx/CMakeLists.txt
@@ -5,6 +5,8 @@ include(GNUInstallDirs)
 # Declare the library (target)
 add_library(cudolfinx)
 
+set_property(TARGET cudolfinx PROPERTY CUDA_ARCHITECTURES 50)
+
 # ------------------------------------------------------------------------------
 # Add source files to the target
 set(CUDOLFINX_DIRS

--- a/cpp/cudolfinx/fem/CMakeLists.txt
+++ b/cpp/cudolfinx/fem/CMakeLists.txt
@@ -7,6 +7,7 @@ set(HEADERS_fem
     ${CMAKE_CURRENT_SOURCE_DIR}/CUDAFormConstants.h
     ${CMAKE_CURRENT_SOURCE_DIR}/CUDAFormCoefficients.h
     ${CMAKE_CURRENT_SOURCE_DIR}/CUDAFormIntegral.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/CUDAInterpolate.h
     ${CMAKE_CURRENT_SOURCE_DIR}/petsc.h
     ${CMAKE_CURRENT_SOURCE_DIR}/utils.h
     PARENT_SCOPE
@@ -16,5 +17,6 @@ target_sources(
   cudolfinx
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/CUDAAssembler.cpp
           ${CMAKE_CURRENT_SOURCE_DIR}/CUDADofMap.cpp
-	  ${CMAKE_CURRENT_SOURCE_DIR}/CUDAFormIntegral.cpp
+          ${CMAKE_CURRENT_SOURCE_DIR}/CUDAFormIntegral.cpp
+          ${CMAKE_CURRENT_SOURCE_DIR}/CUDAInterpolate.cu
 )

--- a/cpp/cudolfinx/fem/CUDACoefficient.h
+++ b/cpp/cudolfinx/fem/CUDACoefficient.h
@@ -6,8 +6,15 @@
 
 #pragma once
 
+#include <cstdint>
 #include <cudolfinx/common/CUDA.h>
+#include <cudolfinx/fem/CUDADofMap.h>
 #include <dolfinx/fem/Function.h>
+#include <dolfinx/fem/interpolate.h>
+#include <memory>
+#include <span>
+#include <vector>
+#include <cudolfinx/fem/CUDAInterpolate.h>
 
 namespace dolfinx::fem
 {
@@ -19,12 +26,24 @@ class CUDACoefficient
 public:
   
   /// @brief Construct a new CUDACoefficient
-  CUDACoefficient(std::shared_ptr<const Function<T, U>> f) {
+  CUDACoefficient(std::shared_ptr<const Function<T, U>> f)
+  {
     _f = f;
     _x = f->x();
+    _values.assign(_x->array().begin(), _x->array().end());
     _dvalues_size = _x->bs() * (_x->index_map()->size_local()+_x->index_map()->num_ghosts()) * sizeof(T);
     CUDA::safeMemAlloc(&_dvalues, _dvalues_size);
     copy_host_values_to_device();
+
+    // Count total no. of cells
+    auto mesh = f->function_space()->mesh();
+    auto map = mesh->topology()->index_map(mesh->topology()->dim());
+    _num_cells = map->size_local() + map->num_ghosts();
+
+    // Create global-to-cell DOF map used for interpolation
+    _M = CUDA::create_interpolation_map(*_f);
+    CUDA::safeMemAlloc(&_dM, _M.size()*sizeof(int));
+    CUDA::safeMemcpyHtoD(_dM, (void*)(_M.data()), _M.size()*sizeof(int));
   }
 
   /// Copy to device, allocating GPU memory if required
@@ -33,28 +52,86 @@ public:
     CUDA::safeMemcpyHtoD(_dvalues, (void*)(_x->array().data()), _dvalues_size);
   }
 
+  void copy_device_values_to_host()
+  {
+    CUDA::safeMemcpyDtoH((void*)_values.data(), _dvalues, _dvalues_size);
+  }
+
+  /// @brief Interpolate from CUDACoefficient `d_g` associated with the same mesh over all cells.
+  /// This updates both host and device coefficient vectors of this object (not the host-side Function).
+  ///
+  /// @pre Both functions must share the same reference map.
+  void interpolate(const CUDACoefficient<T, U>& d_g)
+  {
+    auto element0 = d_g.host_function()->function_space()->element();
+    assert(element0);
+    auto element1 = _f->function_space()->element();
+
+    // Device-side cofficient vector of g
+    CUdeviceptr _dvalues_g = d_g.device_values();
+
+    // Create interpolation operator IM, mapping g to f
+    auto [IM, _im_shape] = element1->create_interpolation_operator(*element0);
+    CUdeviceptr dIM;
+    CUDA::safeMemAlloc(&dIM, IM.size()*sizeof(T));
+    CUDA::safeMemcpyHtoD(dIM, (void*)(IM.data()), IM.size()*sizeof(T));
+
+    CUDA::interpolate_same_map<T>(_dvalues, _dvalues_g, _im_shape, _num_cells, dIM, _dM, d_g.device_dof_matrix());
+
+    copy_device_values_to_host();
+    cuMemFree(dIM);
+  }
+
+
+  /// Return a copy of host-side coefficient vector
+  std::vector<T> values() const
+  {
+    return _values;
+  }
+
   /// Get pointer to vector data on device
   CUdeviceptr device_values() const
   {
     return _dvalues;
   }
 
-  ~CUDACoefficient()
+  /// Get pointer to the underlying Function
+  std::shared_ptr<const dolfinx::fem::Function<T,U>> host_function() const
   {
+    return _f;
+  }
+
+  CUdeviceptr device_dof_matrix() const
+  {
+    return _dM;
+  }
+
+  ~CUDACoefficient() {
     if (_dvalues)
       cuMemFree(_dvalues);
+    if (_dM)
+        cuMemFree(_dM);
   }
 
 private:
-
+  // Host-side coefficient array. Any time _dvalues is updated, this is also updated.
+  std::vector<T> _values;
   // Device-side coefficient array
   CUdeviceptr _dvalues;
   // Size of coefficient array
   size_t _dvalues_size;
   // Pointer to host-side Function
-  std::shared_ptr<const dolfinx::fem::Function<T,U>> _f;
+  std::shared_ptr<const dolfinx::fem::Function<T, U>> _f;
   // Pointer to host-side coefficient vector
   std::shared_ptr<const dolfinx::la::Vector<T>> _x;
+
+  // Total number of cells
+  size_t _num_cells;
+
+  // Interpolation maps
+  std::vector<std::int32_t> _M;
+  CUdeviceptr _dM;
 };
 
+template class dolfinx::fem::CUDACoefficient<double>;
 }

--- a/cpp/cudolfinx/fem/CUDAInterpolate.cu
+++ b/cpp/cudolfinx/fem/CUDAInterpolate.cu
@@ -1,0 +1,82 @@
+#include <cuda.h>
+#include <vector>
+#include <array>
+#include <concepts>
+
+// Assign A with entries of B as specified in M.
+// A and M are of size n.
+template<std::floating_point T>
+__global__ void _mask_right(T* A, const T* B, const int* M, int n) {
+    int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i < n) {
+        A[i] = B[M[i]];
+    }
+}
+
+// Write each entry B[i] to the location M[i] in A.
+// B and M are of size n.
+template<std::floating_point T>
+__global__ void _mask_left(T* A, const T* B, const int* M, int n) {
+    int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i < n) {
+        A[M[i]] = B[i];
+    }
+}
+
+// Compute C = AB
+// A is m x k, B is k x n, C is m x n
+template<std::floating_point T>
+__global__ void _matmul(T* C, const T* A, const T* B, int m, int k, int n) {
+
+    int row = blockIdx.y*blockDim.y + threadIdx.y;
+    int col = blockIdx.x*blockDim.x + threadIdx.x;
+
+    if ((row < m) && (col < n)) {
+        T s = 0;
+        for (int kk = 0; kk < k; kk++) {
+            s += A[row*k + kk] * B[kk*n + col];
+        }
+        C[row*n + col] = s;
+    }
+}
+namespace dolfinx::CUDA {
+
+/// Same-map interpolation kernel.
+///
+/// @param[out] u1 Pointer to device-side coefficient array that will be updated
+/// by the interpolation.
+/// @param[in] u0 Pointer to device-side coefficient array to be interpolated FROM
+/// @param[in] n1 No. of DOF per element of Function to interpolate INTO
+/// @param[in] n0 No. of DOF per element of Function to interpolate FROM
+/// @param[in] C No. of cells in the mesh
+/// @param[in] i_m Pointer to device-side interpolation matrix with dim n1 x n0
+/// @param[in] M1 Pointer to device-side DOF map for u1
+/// @param[in] M0 Pointer to device-side DOF map for u0
+template<std::floating_point T>
+void d_interpolate_same_map(T* u1,
+                            T* u0,
+                            int n1,
+                            int n0, int C,
+                            T* i_m, int* M1, int* M0) {
+
+    T *X0, *X1;
+    cudaMalloc((void **)&X0, n0 * C * sizeof(T));
+    cudaMalloc((void **)&X1, n1 * C * sizeof(T));
+
+    const int numThreads = 128;
+    _mask_right<<<n0 * C / numThreads + 1, numThreads>>>(X0, u0, M0, n0 * C);
+
+    const int matSize = 16;
+    dim3 dimGrid(C / matSize + 1, n1 / matSize + 1, 1);
+    dim3 dimBlock(matSize, matSize, 1);
+    _matmul<<<dimGrid, dimBlock>>>(X1, i_m, X0, n1, n0, C);
+
+    _mask_left<<<n1 * C / numThreads+1 ,numThreads>>>(u1, X1, M1, n1 * C);
+
+    cudaFree(X0);
+    cudaFree(X1);
+}
+
+    template void d_interpolate_same_map<double>(double*, double*, int, int, int, double*, int*, int*);
+    template void d_interpolate_same_map<float>(float*, float*, int, int, int, float*, int*, int*);
+}

--- a/cpp/cudolfinx/fem/CUDAInterpolate.h
+++ b/cpp/cudolfinx/fem/CUDAInterpolate.h
@@ -1,0 +1,101 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <dolfinx/fem/FiniteElement.h>
+#include <dolfinx/fem/Function.h>
+#include <dolfinx/mesh/Geometry.h>
+#include <dolfinx/fem/interpolate.h>
+#include <numeric>
+#include <span>
+#include <stdexcept>
+#include <vector>
+
+namespace dolfinx::CUDA {
+
+template<std::floating_point T>
+void d_interpolate_same_map(T* u1,
+                            T* u0,
+                            int n0,
+                            int n1, int C,
+                            T* i_m, int* M0, int* M1);
+
+/// Same-map interpolation on device.
+///
+/// @param[out] u1 Pointer to device-side coefficient array that will be updated
+/// by the interpolation.
+/// @param[in] u0 Pointer to device-side coefficient array to be interpolated FROM
+/// @param[in] im_shape Shape of interpolation array
+/// @param[in] num_cells No. of cells in the mesh
+/// @param[in] i_m Pointer to device-side interpolation matrix with dim n1 x n0
+/// @param[in] M1 Pointer to device-side DOF map for u1
+/// @param[in] M0 Pointer to device-side DOF map for u0
+template<std::floating_point T>
+void interpolate_same_map(
+                          CUdeviceptr ux1,
+                          CUdeviceptr ux0,
+                          std::array<std::size_t, 2> im_shape,
+                          std::size_t num_cells,
+                          CUdeviceptr i_m,
+                          CUdeviceptr M1,
+                          CUdeviceptr M0) {
+
+
+  const std::size_t n1 = im_shape[0];
+  const std::size_t n0 = im_shape[1];
+
+  d_interpolate_same_map<T>((T*)ux1, (T*)ux0, n1, n0, num_cells, (T*)i_m, (int*)M1, (int*)M0);
+}
+
+/// @brief Create a global-to-cells DOF map for a given Function object.
+/// 
+/// @returns Map for Function u, of size dof_per_elem x num_cells. M[i,c] contains the index of the
+/// global DOF that is mapped to the ith local DOF in cell `c`, in the reference ordering. 
+/// @param[in] u Function object
+template <dolfinx::scalar T, std::floating_point U>
+std::vector<std::int32_t> create_interpolation_map(const dolfinx::fem::Function<T, U> &u) {
+
+  auto V = u.function_space();
+  auto mesh = V->mesh();
+  auto element = V->element();
+
+  const int tdim = mesh->topology()->dim();
+  auto map = mesh->topology()->index_map(tdim);
+
+  std::vector<std::int32_t> cells(map->size_local() + map->num_ghosts(), 0);
+  std::iota(cells.begin(), cells.end(), 0);
+
+  std::span<const std::uint32_t> cell_info;
+  if (element->needs_dof_transformations())
+  {
+    mesh->topology_mutable()->create_entity_permutations();
+    cell_info = std::span(mesh->topology()->get_cell_permutation_info());
+  }
+
+  auto dofmap = V->dofmap();
+
+  // Get block sizes and dof transformation operators
+  const int bs = dofmap->bs();
+  auto apply_dof_transformation = element->template dof_transformation_fn<std::int32_t>(
+      dolfinx::fem::doftransform::transpose, false);
+
+  std::size_t n = element->space_dimension();
+  std::vector<std::int32_t> local_dofs(n);
+  std::vector<std::int32_t> M(cells.size() * n);
+
+  for (std::size_t c = 0; c < cells.size(); c++) {
+    // Pack and transform cell dofs to reference ordering
+    std::span<const std::int32_t> D = dofmap->cell_dofs(cells[c]);
+    // local_dofs0 = [ 0, ..., k-1 ]
+    std::iota(local_dofs.begin(), local_dofs.end(), 0);
+
+    // Permute the vector [0, ..., k-1]
+    apply_dof_transformation(local_dofs, cell_info, cells[c], 1);
+
+    for (std::size_t i = 0; i < n; i++) {
+      M[i * cells.size() + c] = D[local_dofs[i]];
+    }
+  }
+  return M;
+}
+}

--- a/cpp/test/CMakeLists.txt
+++ b/cpp/test/CMakeLists.txt
@@ -1,0 +1,44 @@
+cmake_minimum_required(VERSION 3.18)
+
+project(interpolate)
+
+# Set C++ standard
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_CXX_FLAGS "-O2 -g -pg")
+
+find_package(Basix REQUIRED)
+
+set(MPI_HOME "/usr/local")
+find_package(MPI REQUIRED)
+
+if(Basix_FOUND)
+  message(STATUS "Found Basix at ${Basix_DIR}")
+endif()
+
+find_package(DOLFINX REQUIRED CONFIG)
+if(DOLFINX_FOUND)
+  message(STATUS "Found DOLFINx at ${DOLFINX_DIR}")
+endif()
+
+find_package(CUDOLFINX REQUIRED CONFIG)
+if(CUDOLFINX_FOUND)
+  message(STATUS "Found CUDOLFINx at ${CUDOLFINX_DIR}")
+endif()
+
+find_package(CUDAToolkit REQUIRED)
+
+
+add_executable(interpolate_same_map interpolate_same_map.cpp)
+
+function(link_interpolate name)
+  target_link_libraries(${name} PRIVATE MPI::MPI_CXX)
+  target_link_libraries(${name} PRIVATE dolfinx)
+  target_link_libraries(${name} PRIVATE cudolfinx)
+  target_link_libraries(${name} PRIVATE CUDA::cuda_driver CUDA::nvrtc CUDA::cupti)
+endfunction()
+
+link_interpolate(interpolate_same_map)
+
+

--- a/cpp/test/interpolate_same_map.cpp
+++ b/cpp/test/interpolate_same_map.cpp
@@ -1,0 +1,131 @@
+#include <cstddef>
+#include <cudolfinx/fem/CUDACoefficient.h>
+#include <dolfinx.h>
+#include <dolfinx/fem/FiniteElement.h>
+#include <dolfinx/fem/FunctionSpace.h>
+#include <dolfinx/fem/utils.h>
+#include <dolfinx/mesh/generation.h>
+#include <memory>
+#include <mpi.h>
+#include <stdexcept>
+#include <chrono>
+
+using std::chrono::duration;
+using std::chrono::high_resolution_clock;
+using std::chrono::milliseconds;
+
+template<typename T>
+void printVec(const T& vec) {
+  for (auto v : vec) {
+    std::cout << v << " ";
+  }
+  std::cout << std::endl;
+}
+
+template<typename T, typename U>
+void allClose(const T& v1, const U& v2) {
+  assert(v1.size() == v2.size());
+  for (std::size_t i = 0; i < v1.size(); i++) {
+    assert(std::abs((v1[i] - v2[i])/(v1[i])) < 1e-13);
+  }
+}
+
+using T = double;
+using namespace dolfinx;
+
+int main(int argc, char* argv[]) {
+  init_logging(argc, argv);
+  MPI_Init(&argc, &argv);
+  
+  CUdevice cuDevice = 0;
+  CUcontext cuContext;
+  const char * cuda_err_description;
+
+  cuInit(0);
+  int device_count;
+  CUresult cuda_err = cuDeviceGetCount(&device_count);
+  if (cuda_err != CUDA_SUCCESS) {
+    cuGetErrorString(cuda_err, &cuda_err_description);
+    throw std::runtime_error("cuDeviceGetCount failed with " +
+                             std::string(cuda_err_description) + " at " +
+                             std::string(__FILE__) + ":" +
+                             std::to_string(__LINE__));
+  }
+  std::cout << "No. of devices: " << device_count << std::endl;
+
+  cuCtxCreate(&cuContext, 0, cuDevice);
+  const int num_cells = 30;
+  const T lower = 0.;
+  const T upper = 1.;
+  const int p_order = 5;
+
+  auto element = basix::create_element<T>(
+      basix::element::family::P, basix::cell::type::tetrahedron, p_order,
+      basix::element::lagrange_variant::equispaced,
+      basix::element::dpc_variant::unset, false);
+
+  auto element_from = basix::create_element<T>(
+      basix::element::family::P, basix::cell::type::tetrahedron, 6,
+      basix::element::lagrange_variant::equispaced,
+      basix::element::dpc_variant::unset, false);
+
+  auto e0 = std::make_shared<fem::FiniteElement<T>>(element);
+  auto e1 = std::make_shared<fem::FiniteElement<T>>(element_from);
+
+  const auto mesh = std::make_shared<mesh::Mesh<T>>(mesh::create_box(
+      MPI_COMM_WORLD, {{{lower, lower, lower}, {upper, upper, upper}}},
+      {num_cells, num_cells, num_cells}, mesh::CellType::tetrahedron));
+
+  auto V = std::make_shared<fem::FunctionSpace<T>>(fem::create_functionspace<T>(mesh, e0));
+  auto V_from = std::make_shared<fem::FunctionSpace<T>>(fem::create_functionspace<T>(mesh, e1));
+  auto f = std::make_shared<fem::Function<T>>(V);
+  auto f_true = std::make_shared<fem::Function<T>>(V);
+  auto f_from = std::make_shared<fem::Function<T>>(V_from);
+
+  /* Interpolate the function to interpolate FROM */
+  f_from->interpolate(
+      [](auto x) -> std::pair<std::vector<T>, std::vector<std::size_t>>
+      {
+        std::vector<T> f;
+        for (std::size_t p = 0; p < x.extent(1); ++p)
+        {
+          f.push_back(1 + 0.10*x(0,p)*x(0,p) + 0.2*x(1,p)*x(1,p) + 0.3*x(2,p)*x(2,p));
+        }
+
+        return {f, {f.size()}};
+      });
+
+  /* Reference version */
+  const std::size_t ITER = 5;
+  auto t1 = high_resolution_clock::now();
+  for (std::size_t i = 0; i < ITER; i++)
+    f_true->interpolate(*f_from);
+  auto t2 = high_resolution_clock::now();
+  duration<double, std::milli> ms = t2 - t1;
+  std::cout << "Reference implementation: " << ms.count()/(double)ITER << " ms" << std::endl;
+
+
+  t1 = high_resolution_clock::now();
+  auto coeffs = dolfinx::fem::CUDACoefficient<double>(f) ;
+  t2 = high_resolution_clock::now();
+  ms = t2 - t1;
+  //std::cout << "CUDA initialization: " << ms.count() << " ms" << std::endl;
+
+
+  /* GPU version */
+  auto coeffs_from = dolfinx::fem::CUDACoefficient<double>(f_from);
+  coeffs.interpolate(coeffs_from);
+  t1 = high_resolution_clock::now();
+  for (std::size_t i = 0; i < ITER; i++) {
+    coeffs.interpolate(coeffs_from);
+  }
+  t2 = high_resolution_clock::now();
+  ms = t2 - t1;
+  std::cout << "GPU implementation: " << ms.count()/(double)ITER << " ms" << std::endl;
+  allClose(f_true->x()->array(), coeffs.values());
+
+
+
+  return 0;
+}
+

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -59,6 +59,7 @@ nanobind_add_module(
   cudolfinx/wrappers/cudolfinx.cpp
   cudolfinx/wrappers/fem.cpp
   cudolfinx/wrappers/petsc.cpp
+  cudolfinx/wrappers/coefficient.cpp
 )
 
 # Add strict compiler flags include(CheckCXXCompilerFlag)

--- a/python/cudolfinx/__init__.py
+++ b/python/cudolfinx/__init__.py
@@ -9,3 +9,4 @@
 from cudolfinx.assemble import CUDAAssembler
 from cudolfinx.form import form
 from cudolfinx.mesh import ghost_layer_mesh, ghost_layer_meshtags
+from cudolfinx.coefficient import Coefficient

--- a/python/cudolfinx/coefficient.py
+++ b/python/cudolfinx/coefficient.py
@@ -1,11 +1,23 @@
+# Copyright (C) 2026 Chayanon Wichitrnithed
+#
+# This file is part of cuDOLFINX
+#
+# SPDX-License-Identifier:    LGPL-3.0-or-later
+
+from __future__ import annotations
 from cudolfinx import cpp as _cucpp
 from dolfinx.fem.function import Function
 from cudolfinx.context import get_cuda_context
 import numpy as np
 
 class Coefficient:
+    """CUDA wrapper class for dolfinx.fem.Function.
+    """
     def __init__(self,
                  f: Function):
+        """Initialize with a given dolfinx Function f. Create a copy of
+        the global DOF vector on both host and device.
+        """
         self._ctx = get_cuda_context()
 
         def functiontype(dtype):
@@ -14,13 +26,21 @@ class Coefficient:
             elif np.issubdtype(dtype, np.float64):
                 return _cucpp.fem.CUDACoefficient_float64
             else:
-                raise NotImplementedError(f"Type {dtype} not supported.")
+                raise NotImplementedError(f"Cannot instantiate Coefficient of type {dtype}.")
 
         self._cpp_object = functiontype(f.dtype)(f._cpp_object)
 
     def interpolate(self,
-                    d_g):
-        return self._cpp_object.interpolate(d_g._cpp_object)
+                    coeff0: Coefficient):
+        """Interpolate from another Coefficient object, modifying
+        the global DOF vector. Both must share the
+        same mesh and mapping to reference element.
 
-    def values(self):
+        Args:
+            coeff0: A Coefficient object to interpolate from.
+        """
+        return self._cpp_object.interpolate(coeff0._cpp_object)
+
+    def values(self) -> np.ndarray:
+        """Return a copy of the global DOF vector."""
         return self._cpp_object.values()

--- a/python/cudolfinx/coefficient.py
+++ b/python/cudolfinx/coefficient.py
@@ -1,0 +1,26 @@
+from cudolfinx import cpp as _cucpp
+from dolfinx.fem.function import Function
+from cudolfinx.context import get_cuda_context
+import numpy as np
+
+class Coefficient:
+    def __init__(self,
+                 f: Function):
+        self._ctx = get_cuda_context()
+
+        def functiontype(dtype):
+            if np.issubdtype(dtype, np.float32):
+                return _cucpp.fem.CUDACoefficient_float32
+            elif np.issubdtype(dtype, np.float64):
+                return _cucpp.fem.CUDACoefficient_float64
+            else:
+                raise NotImplementedError(f"Type {dtype} not supported.")
+
+        self._cpp_object = functiontype(f.dtype)(f._cpp_object)
+
+    def interpolate(self,
+                    d_g):
+        return self._cpp_object.interpolate(d_g._cpp_object)
+
+    def values(self):
+        return self._cpp_object.values()

--- a/python/cudolfinx/wrappers/coefficient.cpp
+++ b/python/cudolfinx/wrappers/coefficient.cpp
@@ -1,0 +1,38 @@
+#include <memory>
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/shared_ptr.h>
+#include <nanobind/stl/vector.h>
+#include <nanobind/ndarray.h>
+#include <cudolfinx/fem/CUDACoefficient.h>
+
+
+namespace nb = nanobind;
+
+template <typename T, typename U>
+void declare_cuda_coefficient(nb::module_& m, std::string type)
+{
+  std::string pyclass_name = std::string("CUDACoefficient_") + type;
+  nb::class_<dolfinx::fem::CUDACoefficient<T,U>>(m, pyclass_name.c_str(), "Device side function")
+  .def(nb::init<std::shared_ptr<const dolfinx::fem::Function<T,U>>>(),
+  "Create device side function from a given dolfinx Function object.")
+  .def("interpolate",
+       [](dolfinx::fem::CUDACoefficient<T,U>& self,
+          dolfinx::fem::CUDACoefficient<T,U>& d_g) {
+         self.interpolate(d_g);
+       },
+       "Interpolate from another Function with the same reference element mapping defined on the same mesh.")
+  .def("values",
+       [](dolfinx::fem::CUDACoefficient<T,U>& self) {
+         auto v = self.values();
+         return nb::ndarray<T, nb::numpy, nb::c_contig>(v.data(), {v.size()}).cast();
+       },
+       "Return a copy of the coefficient vector.");
+}
+
+namespace cudolfinx_wrappers
+{
+void coefficient(nb::module_& m) {
+    declare_cuda_coefficient<double,double>(m, "float64");
+    declare_cuda_coefficient<float,float>(m, "float32");
+}
+}

--- a/python/cudolfinx/wrappers/coefficient.cpp
+++ b/python/cudolfinx/wrappers/coefficient.cpp
@@ -1,3 +1,9 @@
+// Copyright (C) 2026 Chayanon Wichitrnithed
+//
+// This file is part of cuDOLFINX
+//
+// SPDX-License-Identifier:    LGPL-3.0-or-later
+
 #include <memory>
 #include <nanobind/nanobind.h>
 #include <nanobind/stl/shared_ptr.h>

--- a/python/cudolfinx/wrappers/cudolfinx.cpp
+++ b/python/cudolfinx/wrappers/cudolfinx.cpp
@@ -12,6 +12,7 @@ namespace cudolfinx_wrappers
 {
 void fem(nb::module_& m);
 void petsc(nb::module_& m_fem);
+void coefficient(nb::module_& m);
 } // namespace cudolfinx_wrappers
 
 NB_MODULE(cpp, m)
@@ -27,4 +28,5 @@ NB_MODULE(cpp, m)
   nb::module_ fem = m.def_submodule("fem", "FEM module");
   cudolfinx_wrappers::fem(fem);
   cudolfinx_wrappers::petsc(fem);
+  cudolfinx_wrappers::coefficient(fem);
 }

--- a/python/examples/interpolate_same_map.py
+++ b/python/examples/interpolate_same_map.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+
+import argparse as ap
+from mpi4py import MPI
+from petsc4py import PETSc
+import cudolfinx as cufem
+from dolfinx import fem, mesh
+from dolfinx.fem import petsc as fe_petsc
+import basix.ufl
+import basix
+import numpy as np
+import time
+
+
+domain = mesh.create_unit_cube(MPI.COMM_WORLD, 20, 20, 20, mesh.CellType.tetrahedron)
+element_to = basix.ufl.element("Lagrange", "tetrahedron", 4)
+V = fem.functionspace(domain, element_to)
+elem_from = basix.ufl.element("Lagrange", "tetrahedron", 5, basix.LagrangeVariant(12))
+V_from = fem.functionspace(domain, elem_from)
+
+u = fem.Function(V)
+u_true = fem.Function(V)
+u_from = fem.Function(V_from)
+
+u_from.interpolate(lambda x: 1 + 0.1*x[0]**2 + 0.2*x[1]**2 + 0.3*x[2]**2)
+
+if __name__ == "__main__":
+    niter = 5
+
+    u_true.interpolate(u_from)
+    start = time.perf_counter()
+    for _ in range(niter):
+        u_true.interpolate(u_from)
+    
+    end = time.perf_counter()
+    print(f"CPU Time: {1e3*(end-start)/niter:.2f} ms")
+
+    ##### GPU code #######################################
+    coeff = cufem.Coefficient(u)
+    coeff_from = cufem.Coefficient(u_from)
+    coeff.interpolate(coeff_from) # initialize
+
+    start = time.perf_counter()
+    for _ in range(niter):
+        coeff.interpolate(coeff_from)
+
+    end = time.perf_counter()
+    print(f"GPU Time: {1e3*(end-start)/niter:.2f} ms")
+
+    assert np.allclose(u_true.x.array, coeff.values(), rtol=1e-12)
+    print("PASSED")


### PR DESCRIPTION
# Notation

-   $u_0$: function object to interpolate from. Has $n_0$ DOF per element.
-   $[u_0]$: global DOF vector of $u_0$.
-   $u_1$: function object to interpolate into. Has $n_1$ DOF per element.
-   $[u_1]$: global DOF vector of $u_1$.
-   $C$: number of cells in the mesh.
-   $M_I$: interpolation operator (matrix) between two elements. Dim: $n_1 \times n_0$.
-   $M_0$: global-to-cells DOF map for $u_0$ of dim $n_0 \times C$. $M_0[i,c]$
    contains the global DOF number of the $i^{th}$ local DOF in cell $c$ of $u_0$,
    in the reference element ordering.
-   $M_1$: same as above but for $u_1$. Dim: $n_1 \times C$.


<a id="org4a94e31"></a>

# Interpolation procedure

1.  Create the mappings $M_0,M_1$.
2.  Create the interpolation operator $M_I$.
3.  Pack and permute the global DOF vector $[u_0]$ into dof-by-cell layout $X_0$ with the
    ordering of the reference element.
    $$X_0[i,c] := [u_0][M_0[i,c]]$$
4.  Compute the result $X_1$ in the dof-by-cell layout
    $$X_1 := M_IX_0$$
5.  Unpack the result into the global DOF vector of $u_1$:
    $$[u_1][M_1[i,c]] := X_1[i,c]$$


<a id="orgc266f6f"></a>

# Implementation

-   Use the CUDACoefficient class which now also maintains a host-side copy of the
    global DOF vector. Current API is `u1.interpolate(u0)`, and both are
    CUDACoefficient objects.
-   Step 1 is done once when initializing CUDACoefficient objects for $u_0,u_1$.
-   Step 2 is cheap and is done every time interpolation is called.
-   Steps 3-5 are done on the GPU. Both host and device side global coefficients
    of $u_1$ are updated. Currently a non-optimized matmul is used for Step 4.
-   Tests are in `interpolate_same_map.cpp` and `interpolate_same_map.py` for
    interpolating between Lagrange elements of different orders.
-   The kernels for Steps 3-5 are in `CUDAInterpolate.cu` to isolate NVCC
    compilation. There seems to be an error when NVCC sees dolfinx-related headers.

