### PR TITLE
Fix Dockerfile.test-env

### DIFF
--- a/docker/Dockerfile.test-env
+++ b/docker/Dockerfile.test-env
@@ -58,7 +58,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     cmake \
     g++ \
     gfortran \
-    libboost-dev \
+    libboost-all-dev \
     liblapack-dev \
     libopenblas-dev \
     libpugixml-dev \
@@ -141,7 +141,8 @@ ENV PETSC_OPTIONS="-use_gpu_aware_mpi 0" \
     PATH=/usr/local/bin:$PATH
 
 # Install Python packages (via pip)
-RUN pip install --no-cache-dir --upgrade pip setuptools wheel && \
+RUN pip install --no-cache-dir --upgrade pip wheel && \
+    pip install 'setuptools<81.0.0' && \
     pip install --no-cache-dir cython numpy==${NUMPY_VERSION} && \
     pip install --no-cache-dir mpi4py
 


### PR DESCRIPTION
- Use `libboost-all-dev` to support running the fenics "performance-test" suite.

- Downgrade Python `setuptools` to avoid bug https://gitlab.com/petsc/petsc/-/issues/1855