### PR TITLE
add high-level PETSc SNES interface for nonlinear problems

### DIFF
--- a/python/cudolfinx/la.py
+++ b/python/cudolfinx/la.py
@@ -10,13 +10,13 @@ class CUDAVector:
   """Vector on device
   """
 
-  def __init__(self, ctx, vec):
+  def __init__(self, ctx, vec, include_ghosts: bool = False):
     """Initialize the vector
     """
 
     self._petsc_vec = vec
     self._ctx = ctx
-    self._cpp_object = _cucpp.fem.CUDAVector(ctx, self._petsc_vec)
+    self._cpp_object = _cucpp.fem.CUDAVector(ctx, self._petsc_vec, include_ghosts)
 
   @property
   def vector(self):
@@ -30,6 +30,12 @@ class CUDAVector:
     """
 
     self._cpp_object.to_host(self._ctx)
+
+  def to_device(self):
+    """Copy host-side values (including ghosts) to device
+    """
+
+    self._cpp_object.to_device(self._ctx)
 
   def __del__(self):
     """Delete the vector and free up GPU resources

--- a/python/cudolfinx/petsc.py
+++ b/python/cudolfinx/petsc.py
@@ -107,6 +107,9 @@ class NonlinearProblem:
         # solution work vector for SNES (plain PETSc Vec with same layout as b)
         self._x: PETSc.Vec = self._cuda_b.vector.copy()  # type: ignore[attr-defined]
 
+        # persistent CUDA vector wrapping u (owned + ghost DOFs) for residual assembly
+        self._cuda_u = CUDAVector(self._assembler._ctx, u.x.petsc_vec, include_ghosts=True)
+
         # SNES object
         self._snes: PETSc.SNES = PETSc.SNES().create(  # type: ignore[attr-defined]
             self._cuda_b.vector.comm
@@ -154,14 +157,14 @@ class NonlinearProblem:
         and not the original residual vector created in ``__init__``
         """
 
-        # copy x to u
+        # copy x to u and update ghosts
         x.copy(self._u.x.petsc_vec)
         self._u.x.petsc_vec.ghostUpdate(
             addv=PETSc.InsertMode.INSERT, mode=PETSc.ScatterMode.FORWARD
         )
 
-        # create CUDA vector wrapping u's petsc vec (already ghost-updated)
-        x_cuda = CUDAVector(self._assembler._ctx, self._u.x.petsc_vec)
+        # update the persistent CUDA vector with the current u values (including ghosts)
+        self._cuda_u.to_device()
 
         # assemble and apply BCs
         self._assembler.assemble_vector(self._cuda_F, self._cuda_b, zero=True)
@@ -169,14 +172,14 @@ class NonlinearProblem:
             self._cuda_b,
             [self._cuda_J],
             [self._cuda_bcs],
-            x0=[x_cuda],
+            x0=[self._cuda_u],
             scale=-1.0,
         )
         self._assembler.set_bc(
             self._cuda_b,
             bcs=self._cuda_bcs,
             V=self._u.function_space,
-            x0=x_cuda,
+            x0=self._cuda_u,
             scale=-1.0,
         )
 

--- a/python/cudolfinx/petsc.py
+++ b/python/cudolfinx/petsc.py
@@ -1,0 +1,316 @@
+# Copyright (C) 2026 Jonas Heinzmann, Benjamin Pachev
+#
+# This file is part of cuDOLFINX
+#
+# SPDX-License-Identifier:    LGPL-3.0-or-later
+
+from __future__ import annotations
+
+from typing import Sequence
+
+import ufl
+from dolfinx.fem.bcs import DirichletBC
+from dolfinx.fem.forms import Form
+from dolfinx.fem.function import Function
+from cudolfinx.assemble import CUDAAssembler
+from cudolfinx.form import CUDAForm, form as _cuda_form
+from cudolfinx.la import CUDAMatrix, CUDAVector
+from petsc4py import PETSc
+
+
+class NonlinearProblem:
+    """
+    High-level class for solving nonlinear variational problems
+    with PETSc SNES on the GPU, adapted from and and resembling
+    the interface of dolfinx.fem.petsc.NonlinearProblem
+    """
+
+    def __init__(
+        self,
+        F: ufl.Form,
+        u: Function,
+        *,
+        petsc_options_prefix: str,
+        bcs: Sequence[DirichletBC] | None = None,
+        J: ufl.Form | None = None,
+        P: ufl.Form | None = None,
+        petsc_options: dict | None = None,
+        cuda_jit_options: dict | None = None,
+    ):
+        """
+        Initialise the GPU nonlinear problem
+
+        Args:
+        F: UFL form(s) representing the residual
+        u: Current-iterate function(s). Must be the same object(s)
+            used as coefficients in ``F`` and ``J``
+        petsc_options_prefix: Mandatory options prefix used as root
+            prefix on all internally created PETSc objects
+        bcs: Dirichlet boundary conditions
+        J: UFL form(s) for the Jacobian. Derived automatically via
+            ``ufl.derivative`` when not provided (single-form only)
+        P: UFL form(s) for an optional preconditioner matrix
+        petsc_options: Options forwarded to the PETSc SNES solver
+        cuda_jit_options: Passed to the CUDA JIT compiler
+
+        """
+
+        # TODO: extend to block/multi-form problems
+        assert isinstance(F, ufl.Form), "Currently only single residual forms are supported"
+        if J is not None:
+            assert isinstance(J, ufl.Form), "Currently only single Jacobian forms are supported"
+        if P is not None:
+            assert isinstance(P, ufl.Form), (
+                "Currently only single preconditioner forms are supported"
+            )
+
+        if petsc_options_prefix == "":
+            raise ValueError("PETSc options prefix cannot be empty.")
+
+        self._assembler = CUDAAssembler()
+
+        self._u = u
+
+        bcs = [] if bcs is None else list(bcs)
+        self._bcs = bcs
+
+        self._cuda_bcs = self._assembler.pack_bcs(bcs)
+
+        if J is None:
+            J = ufl.derivative(F, u, ufl.TrialFunction(u.function_space))
+
+        # instantiate CUDA forms
+        self._cuda_F: CUDAForm = _cuda_form(F, cuda_jit_args=cuda_jit_options or {})
+        self._cuda_J: CUDAForm = _cuda_form(J, cuda_jit_args=cuda_jit_options or {})
+        self._cuda_P: CUDAForm | None = (
+            _cuda_form(P, cuda_jit_args=cuda_jit_options or {}) if P is not None else None
+        )
+
+        # Jacobian matrix (CUDA-backed PETSc Mat)
+        self._cuda_A = self._assembler.create_matrix(self._cuda_J)
+
+        # preconditioner matrix
+        if self._cuda_P is not None:
+            self._cuda_P_mat = self._assembler.create_matrix(self._cuda_P)
+        else:
+            self._cuda_P_mat = None
+
+        # residual vector (CUDA-backed PETSc Vec)
+        self._cuda_b = self._assembler.create_vector(self._cuda_F)
+
+        # solution work vector for SNES (plain PETSc Vec with same layout as b)
+        self._x: PETSc.Vec = self._cuda_b.vector.copy()  # type: ignore[attr-defined]
+
+        # SNES object
+        self._snes: PETSc.SNES = PETSc.SNES().create(  # type: ignore[attr-defined]
+            self._cuda_b.vector.comm
+        )
+
+        self._snes.setFunction(self._assemble_residual, self._cuda_b.vector)
+        self._snes.setJacobian(
+            self._assemble_jacobian,
+            self._cuda_A.mat,
+            self._cuda_P_mat.mat if self._cuda_P_mat is not None else None,
+        )
+
+        # options prefixes
+        self._snes.setOptionsPrefix(petsc_options_prefix)
+        self._cuda_A.mat.setOptionsPrefix(f"{petsc_options_prefix}A_")
+        if self._cuda_P_mat is not None:
+            self._cuda_P_mat.mat.setOptionsPrefix(f"{petsc_options_prefix}P_mat_")
+        self._cuda_b.vector.setOptionsPrefix(f"{petsc_options_prefix}b_")
+        self._x.setOptionsPrefix(f"{petsc_options_prefix}x_")
+
+        # forward SNES options
+        if petsc_options is not None:
+            opts = PETSc.Options()  # type: ignore[attr-defined]
+            opts.prefixPush(self._snes.getOptionsPrefix())
+            for k, v in petsc_options.items():
+                opts[k] = v
+            self._snes.setFromOptions()
+            for k in petsc_options:
+                del opts[k]
+            opts.prefixPop()
+
+    def _assemble_residual(
+        self,
+        snes: PETSc.SNES,  # type: ignore[name-defined]
+        x: PETSc.Vec,  # type: ignore[name-defined]
+        b: PETSc.Vec,  # type: ignore[name-defined]
+    ) -> None:
+        """
+        Assemble the residual ``F(u)`` on the GPU, called by PETSc SNES
+        on every function evaluation
+
+        Note: For the line searches, PETSc has an internal work vector
+        also for the residual, which it passes as the ``b`` argument to this function.
+        This is the vector that must be updated with the assembled residual,
+        and not the original residual vector created in ``__init__``
+        """
+
+        # copy x to u
+        x.copy(self._u.x.petsc_vec)
+        self._u.x.petsc_vec.ghostUpdate(
+            addv=PETSc.InsertMode.INSERT, mode=PETSc.ScatterMode.FORWARD
+        )
+
+        # assemble and apply BCs
+        self._assembler.assemble_vector(self._cuda_F, self._cuda_b, zero=True)
+        self._assembler.apply_lifting(self._cuda_b, [self._cuda_J], [self._cuda_bcs])
+        self._assembler.set_bc(self._cuda_b, bcs=self._cuda_bcs, V=self._u.function_space)
+
+        # copy assembled vector to PETSc work vector
+        self._cuda_b.vector.copy(b)
+
+    def _assemble_jacobian(
+        self,
+        snes: PETSc.SNES,  # type: ignore[name-defined]
+        x: PETSc.Vec,  # type: ignore[name-defined]
+        A: PETSc.Mat,  # type: ignore[name-defined]
+        P: PETSc.Mat,  # type: ignore[name-defined]
+    ) -> None:
+        """
+        Assemble the Jacobian (and optional preconditioner) on the GPU,
+        called by PETSc SNES on every Jacobian evaluation
+        """
+
+        # copy x to u
+        x.copy(self._u.x.petsc_vec)
+        self._u.x.petsc_vec.ghostUpdate(
+            addv=PETSc.InsertMode.INSERT, mode=PETSc.ScatterMode.FORWARD
+        )
+
+        # assemble Jacobian
+        self._assembler.assemble_matrix(self._cuda_J, self._cuda_A, bcs=self._cuda_bcs)
+        self._cuda_A.assemble()
+        A.assemble()
+
+        # assemble preconditioner
+        if self._cuda_P_mat is not None and self._cuda_P is not None:
+            self._assembler.assemble_matrix(self._cuda_P, self._cuda_P_mat, bcs=self._cuda_bcs)
+            self._cuda_P_mat.assemble()
+            P.assemble()
+
+    def solve(self) -> Function | Sequence[Function]:
+        """
+        solve the nonlinear problem with PETSc SNES
+
+        Note:
+        It is the caller's responsibility to check convergence, either with
+        assert problem.solver.getConvergedReason() > 0
+        or by configuring SNES options to raise an error on non-convergence
+        petsc_options = {"snes_error_if_not_converged": True}
+
+        For the line searches, PETSc has internal work vectors for the solution,
+        which it passes as the ``x`` argument to the SNES functions.
+        This is the vector that is updated with the solution, and must not
+        share memory with self._u at which the residual, and Jacobian
+        (and preconditioner) are defined. Hence, the solution must be copied
+        from self._u to the SNES work vector before solving, and back to self._u
+        after solving
+
+        Returns:
+        The updated solution function(s) ``u``
+        """
+
+        # copy u to x
+        self._u.x.petsc_vec.copy(self._x)
+        self._u.x.petsc_vec.ghostUpdate(
+            addv=PETSc.InsertMode.INSERT, mode=PETSc.ScatterMode.FORWARD
+        )
+
+        # solve
+        self._snes.solve(None, self._x)
+
+        # copy x to u
+        self._x.copy(self._u.x.petsc_vec)
+        self._u.x.petsc_vec.ghostUpdate(
+            addv=PETSc.InsertMode.INSERT, mode=PETSc.ScatterMode.FORWARD
+        )
+
+        return self._u
+
+    def __del__(self) -> None:
+        """Destroy PETSc objects created internally"""
+        for obj in filter(
+            None,
+            (
+                self._snes,
+                self._cuda_A.mat if self._cuda_A is not None else None,
+                self._cuda_P_mat.mat if self._cuda_P_mat is not None else None,
+                self._cuda_b.vector if self._cuda_b is not None else None,
+                self._x,
+            ),
+        ):
+            try:
+                obj.destroy()
+            except Exception:
+                pass
+
+    @property
+    def F(self) -> Form:
+        """Compiled dolfinx residual form"""
+        return self._cuda_F.dolfinx_form
+
+    @property
+    def J(self) -> Form:
+        """Compiled dolfinx Jacobian form"""
+        return self._cuda_J.dolfinx_form
+
+    @property
+    def preconditioner(self) -> Form:
+        """Compiled dolfinx preconditioner form, or ``None``."""
+        if self._cuda_P is None:
+            return None
+
+        return self._cuda_P.dolfinx_form
+
+    @property
+    def cuda_F(self) -> CUDAForm:
+        """GPU residual form"""
+        return self._cuda_F
+
+    @property
+    def cuda_J(self) -> CUDAForm:
+        """GPU Jacobian form"""
+        return self._cuda_J
+
+    @property
+    def cuda_A(self) -> CUDAMatrix:
+        """GPU Jacobian matrix"""
+        return self._cuda_A
+
+    @property
+    def cuda_b(self) -> CUDAVector:
+        """GPU residual vector"""
+        return self._cuda_b
+
+    @property
+    def A(self) -> PETSc.Mat:  # type: ignore[name-defined]
+        """Jacobian matrix (host-side PETSc Mat)"""
+        return self._cuda_A.mat
+
+    @property
+    def P_mat(self) -> PETSc.Mat | None:  # type: ignore[name-defined]
+        """Preconditioner matrix (host-side PETSc Mat), or ``None``"""
+        return self._cuda_P_mat.mat if self._cuda_P_mat is not None else None
+
+    @property
+    def b(self) -> PETSc.Vec:  # type: ignore[name-defined]
+        """Residual vector (host-side PETSc Vec)"""
+        return self._cuda_b.vector
+
+    @property
+    def x(self) -> PETSc.Vec:  # type: ignore[name-defined]
+        """SNES solution work vector"""
+        return self._x
+
+    @property
+    def solver(self) -> PETSc.SNES:  # type: ignore[name-defined]
+        """The underlying PETSc SNES solver"""
+        return self._snes
+
+    @property
+    def u(self) -> Function:
+        """Solution function"""
+        return self._u

--- a/python/cudolfinx/petsc.py
+++ b/python/cudolfinx/petsc.py
@@ -23,6 +23,8 @@ class NonlinearProblem:
     High-level class for solving nonlinear variational problems
     with PETSc SNES on the GPU, adapted from and and resembling
     the interface of dolfinx.fem.petsc.NonlinearProblem
+
+    (currently not supporting block/multi-form problems)
     """
 
     def __init__(
@@ -52,30 +54,34 @@ class NonlinearProblem:
         P: UFL form(s) for an optional preconditioner matrix
         petsc_options: Options forwarded to the PETSc SNES solver
         cuda_jit_options: Passed to the CUDA JIT compiler
-
         """
 
-        # TODO: extend to block/multi-form problems
-        assert isinstance(F, ufl.Form), "Currently only single residual forms are supported"
+        # check types of forms
+        assert isinstance(F, ufl.Form), (
+            f"F must be a ufl.Form, got {type(F).__name__}. "
+            "Block/multi-form problems are not yet supported."
+        )
         if J is not None:
-            assert isinstance(J, ufl.Form), "Currently only single Jacobian forms are supported"
+            assert isinstance(J, ufl.Form), (
+                f"J must be a ufl.Form, got {type(J).__name__}. "
+                "Block/multi-form problems are not yet supported."
+            )
         if P is not None:
             assert isinstance(P, ufl.Form), (
-                "Currently only single preconditioner forms are supported"
+                f"P must be a ufl.Form, got {type(P).__name__}. "
+                "Block/multi-form problems are not yet supported."
             )
 
         if petsc_options_prefix == "":
             raise ValueError("PETSc options prefix cannot be empty.")
 
         self._assembler = CUDAAssembler()
-
         self._u = u
-
         bcs = [] if bcs is None else list(bcs)
         self._bcs = bcs
-
         self._cuda_bcs = self._assembler.pack_bcs(bcs)
 
+        # automatically derive Jacobian form if not provided
         if J is None:
             J = ufl.derivative(F, u, ufl.TrialFunction(u.function_space))
 
@@ -86,7 +92,7 @@ class NonlinearProblem:
             _cuda_form(P, cuda_jit_args=cuda_jit_options or {}) if P is not None else None
         )
 
-        # Jacobian matrix (CUDA-backed PETSc Mat)
+        # Jacobian matrix
         self._cuda_A = self._assembler.create_matrix(self._cuda_J)
 
         # preconditioner matrix
@@ -95,7 +101,7 @@ class NonlinearProblem:
         else:
             self._cuda_P_mat = None
 
-        # residual vector (CUDA-backed PETSc Vec)
+        # residual vector
         self._cuda_b = self._assembler.create_vector(self._cuda_F)
 
         # solution work vector for SNES (plain PETSc Vec with same layout as b)
@@ -154,21 +160,21 @@ class NonlinearProblem:
             addv=PETSc.InsertMode.INSERT, mode=PETSc.ScatterMode.FORWARD
         )
 
-        # create CUDA vector for x for BC application
-        x_cuda = CUDAVector(self._assembler._ctx, x)
+        # create CUDA vector wrapping u's petsc vec (already ghost-updated)
+        x_cuda = CUDAVector(self._assembler._ctx, self._u.x.petsc_vec)
 
         # assemble and apply BCs
         self._assembler.assemble_vector(self._cuda_F, self._cuda_b, zero=True)
         self._assembler.apply_lifting(
             self._cuda_b,
             [self._cuda_J],
-            [self._bcs],
+            [self._cuda_bcs],
             x0=[x_cuda],
             scale=-1.0,
         )
         self._assembler.set_bc(
             self._cuda_b,
-            bcs=self._bcs,
+            bcs=self._cuda_bcs,
             V=self._u.function_space,
             x0=x_cuda,
             scale=-1.0,
@@ -206,7 +212,7 @@ class NonlinearProblem:
             self._cuda_P_mat.assemble()
             P.assemble()
 
-    def solve(self) -> Function | Sequence[Function]:
+    def solve(self) -> Function:
         """
         solve the nonlinear problem with PETSc SNES
 
@@ -233,6 +239,9 @@ class NonlinearProblem:
             addv=PETSc.InsertMode.INSERT, mode=PETSc.ScatterMode.FORWARD
         )
         self._u.x.petsc_vec.copy(self._x)
+
+        # update BCs
+        self._cuda_bcs.update(self._bcs)
 
         # solve
         self._snes.solve(None, self._x)

--- a/python/cudolfinx/petsc.py
+++ b/python/cudolfinx/petsc.py
@@ -112,7 +112,7 @@ class NonlinearProblem:
 
         # SNES object
         self._snes: PETSc.SNES = PETSc.SNES().create(  # type: ignore[attr-defined]
-            self._cuda_b.vector.comm
+            u.function_space.mesh.comm
         )
 
         self._snes.setFunction(self._assemble_residual, self._cuda_b.vector)
@@ -166,25 +166,25 @@ class NonlinearProblem:
         # update the persistent CUDA vector with the current u values (including ghosts)
         self._cuda_u.to_device()
 
+        # wrap b vector passed in from SNES and assemble directly into it, avoiding a copy
+        cuda_b = CUDAVector(self._assembler._ctx, b)
+
         # assemble and apply BCs
-        self._assembler.assemble_vector(self._cuda_F, self._cuda_b, zero=True)
+        self._assembler.assemble_vector(self._cuda_F, cuda_b, zero=True)
         self._assembler.apply_lifting(
-            self._cuda_b,
+            cuda_b,
             [self._cuda_J],
             [self._cuda_bcs],
             x0=[self._cuda_u],
             scale=-1.0,
         )
         self._assembler.set_bc(
-            self._cuda_b,
+            cuda_b,
             bcs=self._cuda_bcs,
             V=self._u.function_space,
             x0=self._cuda_u,
             scale=-1.0,
         )
-
-        # copy assembled vector to PETSc work vector
-        self._cuda_b.vector.copy(b)
 
     def _assemble_jacobian(
         self,

--- a/python/cudolfinx/petsc.py
+++ b/python/cudolfinx/petsc.py
@@ -154,10 +154,25 @@ class NonlinearProblem:
             addv=PETSc.InsertMode.INSERT, mode=PETSc.ScatterMode.FORWARD
         )
 
+        # create CUDA vector for x for BC application
+        x_cuda = CUDAVector(self._assembler._ctx, x)
+
         # assemble and apply BCs
         self._assembler.assemble_vector(self._cuda_F, self._cuda_b, zero=True)
-        self._assembler.apply_lifting(self._cuda_b, [self._cuda_J], [self._cuda_bcs])
-        self._assembler.set_bc(self._cuda_b, bcs=self._cuda_bcs, V=self._u.function_space)
+        self._assembler.apply_lifting(
+            self._cuda_b,
+            [self._cuda_J],
+            [self._bcs],
+            x0=[x_cuda],
+            scale=-1.0,
+        )
+        self._assembler.set_bc(
+            self._cuda_b,
+            bcs=self._bcs,
+            V=self._u.function_space,
+            x0=x_cuda,
+            scale=-1.0,
+        )
 
         # copy assembled vector to PETSc work vector
         self._cuda_b.vector.copy(b)
@@ -214,10 +229,10 @@ class NonlinearProblem:
         """
 
         # copy u to x
-        self._u.x.petsc_vec.copy(self._x)
         self._u.x.petsc_vec.ghostUpdate(
             addv=PETSc.InsertMode.INSERT, mode=PETSc.ScatterMode.FORWARD
         )
+        self._u.x.petsc_vec.copy(self._x)
 
         # solve
         self._snes.solve(None, self._x)

--- a/python/cudolfinx/wrappers/fem.cpp
+++ b/python/cudolfinx/wrappers/fem.cpp
@@ -190,10 +190,12 @@ void declare_cuda_objects(nb::module_& m)
   nb::class_<dolfinx::la::CUDAVector>(m, "CUDAVector", "Vector object on GPU")
       .def(
           "__init__",
-          [](dolfinx::la::CUDAVector* cuvec, const dolfinx::CUDA::Context& cuda_context, Vec x) {
-            new (cuvec) dolfinx::la::CUDAVector(cuda_context, x, false, false);
-          }, nb::arg("context"), nb::arg("x"))
+          [](dolfinx::la::CUDAVector* cuvec, const dolfinx::CUDA::Context& cuda_context,
+             Vec x, bool include_ghosts) {
+            new (cuvec) dolfinx::la::CUDAVector(cuda_context, x, false, include_ghosts);
+          }, nb::arg("context"), nb::arg("x"), nb::arg("include_ghosts") = false)
       .def("to_host", &dolfinx::la::CUDAVector::copy_vector_values_to_host)
+      .def("to_device", &dolfinx::la::CUDAVector::copy_vector_values_to_device)
       .def_prop_ro("vector",
           [](dolfinx::la::CUDAVector& cuvec) {
             Vec b = cuvec.vector();

--- a/python/examples/nonlinear.py
+++ b/python/examples/nonlinear.py
@@ -20,6 +20,8 @@ from ufl import dx, grad, inner
 import dolfinx
 from dolfinx import mesh
 from dolfinx.fem.petsc import NonlinearProblem
+
+import cudolfinx as cufem
 from cudolfinx.petsc import NonlinearProblem as cuNonlinearProblem
 
 # petsc logging to see GPU utilization, CpuToGpu and GpuToCpu times, etc.
@@ -45,6 +47,11 @@ def main(res: int = 30, degree: int = 1, dim: int = 3, cuda: bool = True):
 
     domain = create_mesh(res, dim=dim)
     comm = domain.comm
+
+    if cuda and comm.size > 1:
+        if comm.rank == 0:
+            print("Using ghost layer mesh for CUDA Assembly")
+        domain = cufem.ghost_layer_mesh(domain)
 
     V = dolfinx.fem.functionspace(domain, ("Lagrange", degree))
 

--- a/python/examples/nonlinear.py
+++ b/python/examples/nonlinear.py
@@ -91,10 +91,12 @@ def main(res: int = 30, degree: int = 1, dim: int = 3, cuda: bool = True):
         "snes_atol": 1e-10,
         "snes_max_it": 25,
         "snes_converged_reason": "",
+        "snes_error_if_not_converged": True,
         "ksp_type": "cg",
         "ksp_rtol": 1e-12,
         "ksp_max_it": 500,
         "ksp_converged_reason": "",
+        "ksp_error_if_not_converged": True,
         "pc_type": "gamg",
     }
 

--- a/python/examples/nonlinear.py
+++ b/python/examples/nonlinear.py
@@ -1,0 +1,152 @@
+# Copyright (C) 2026 Jonas Heinzmann, Benjamin Pachev
+#
+# This file is part of cuDOLFINX
+#
+# SPDX-License-Identifier:    LGPL-3.0-or-later
+
+import argparse as ap
+import time
+
+from mpi4py import MPI
+import petsc4py
+
+petsc4py.init(comm=MPI.COMM_WORLD)
+from petsc4py import PETSc
+
+import numpy as np
+import ufl
+from ufl import dx, grad, inner
+
+import dolfinx
+from dolfinx import mesh
+from dolfinx.fem.petsc import NonlinearProblem
+from cudolfinx.petsc import NonlinearProblem as cuNonlinearProblem
+
+# petsc logging to see GPU utilization, CpuToGpu and GpuToCpu times, etc.
+opts = PETSc.Options()
+opts.setValue("log_view", ":petsc.log")
+PETSc.Log.begin()
+
+
+def create_mesh(res: int = 10, dim: int = 3):
+    if dim == 3:
+        return mesh.create_box(
+            comm=MPI.COMM_WORLD,
+            points=((0.0, 0.0, 0.0), (1.0, 1.0, 1.0)),
+            n=(res, res, res),
+            cell_type=mesh.CellType.tetrahedron,
+        )
+    else:
+        return mesh.create_unit_square(MPI.COMM_WORLD, res, res)
+
+
+def main(res: int = 30, degree: int = 1, dim: int = 3, cuda: bool = True):
+    """solve a nonlinear problem on a CPU or GPU"""
+
+    domain = create_mesh(res, dim=dim)
+    comm = domain.comm
+
+    V = dolfinx.fem.functionspace(domain, ("Lagrange", degree))
+
+    if comm.rank == 0:
+        dofs_global = V.dofmap.index_map.size_global
+        elements_global = domain.topology.index_map(domain.topology.dim).size_global
+        print(f"{elements_global} elements, {dofs_global} DOFs\n")
+
+    u = dolfinx.fem.Function(V)
+    v = ufl.TestFunction(V)
+
+    x = ufl.SpatialCoordinate(domain)
+
+    if dim == 3:
+        f = 10.0 * ufl.exp(-((x[0] - 0.5) ** 2 + (x[1] - 0.5) ** 2 + (x[2] - 0.5) ** 2) / 0.02)
+    else:
+        f = 10.0 * ufl.exp(-((x[0] - 0.5) ** 2 + (x[1] - 0.5) ** 2) / 0.02)
+
+    F = (1.0 + u**2) * inner(grad(u), grad(v)) * dx - f * v * dx
+    J = ufl.derivative(F, u)
+
+    boundary_facets = mesh.locate_entities_boundary(
+        domain,
+        dim=domain.topology.dim - 1,
+        marker=lambda x: np.ones(x.shape[1], dtype=bool),
+    )
+    dofs = dolfinx.fem.locate_dofs_topological(V, domain.topology.dim - 1, boundary_facets)
+    bc = dolfinx.fem.dirichletbc(PETSc.ScalarType(0.0), dofs, V)
+
+    petsc_options = {
+        "snes_type": "newtonls",
+        "snes_monitor": "",
+        "snes_linesearch_type": "bisection",
+        "snes_linesearch_damping": 1.0,
+        "snes_linesearch_monitor": "",
+        "snes_rtol": 1e-8,
+        "snes_atol": 1e-10,
+        "snes_max_it": 25,
+        "snes_converged_reason": "",
+        "ksp_type": "cg",
+        "ksp_rtol": 1e-12,
+        "ksp_max_it": 500,
+        "ksp_converged_reason": "",
+        "pc_type": "gamg",
+    }
+
+    if cuda:
+        # GPU version
+        problem = cuNonlinearProblem(
+            F,
+            u,
+            petsc_options_prefix="nl_",
+            bcs=[bc],
+            petsc_options=petsc_options,
+            J=J,
+        )
+    else:
+        # CPU version
+        problem = NonlinearProblem(
+            F,
+            u,
+            petsc_options_prefix="nl_",
+            bcs=[bc],
+            petsc_options=petsc_options,
+            J=J,
+        )
+
+    t0 = time.perf_counter()
+    problem.solve()
+    comm.Barrier()
+    elapsed = time.perf_counter() - t0
+
+    if comm.rank == 0:
+        print(f"\nelapsed time: {elapsed:.3f} s {'(GPU)' if cuda else '(CPU)'}")
+
+
+if __name__ == "__main__":
+    parser = ap.ArgumentParser(description="Nonlinear problem demo using NonlinearProblem class")
+    parser.add_argument(
+        "--res",
+        default=10,
+        type=int,
+        help="Number of subdivisions per dimension (default: 10)",
+    )
+    parser.add_argument(
+        "--degree",
+        default=1,
+        type=int,
+        help="Lagrange polynomial degree (default: 1)",
+    )
+    parser.add_argument(
+        "--dim",
+        default=3,
+        type=int,
+        choices=[2, 3],
+        help="Spatial dimension (default: 3)",
+    )
+    parser.add_argument(
+        "--no-cuda",
+        action="store_true",
+        help="Run only the CPU version (default: False)",
+    )
+    args = parser.parse_args()
+
+    main(res=args.res, degree=args.degree, dim=args.dim, cuda=not args.no_cuda)

--- a/python/test/test_nonlinear_problem.py
+++ b/python/test/test_nonlinear_problem.py
@@ -1,0 +1,148 @@
+# Copyright (C) 2026 Jonas Heinzmann, Benjamin Pachev
+#
+# This file is part of cuDOLFINX
+#
+# SPDX-License-Identifier:    LGPL-3.0-or-later
+
+import numpy as np
+import ufl
+from ufl import dx, grad, inner
+from mpi4py import MPI
+from petsc4py import PETSc
+import dolfinx
+from dolfinx import fem, mesh
+from dolfinx.fem.petsc import NonlinearProblem
+import cudolfinx as cufem
+from cudolfinx.petsc import NonlinearProblem as cuNonlinearProblem
+
+# resolution
+RES = 50
+
+petsc_options = {
+    "snes_type": "newtonls",
+    "snes_monitor": "",
+    "snes_linesearch_type": "bisection",
+    "snes_linesearch_damping": 1.0,
+    "snes_linesearch_monitor": "",
+    "snes_rtol": 1e-8,
+    "snes_atol": 1e-10,
+    "snes_max_it": 25,
+    "snes_converged_reason": "",
+    "snes_error_if_not_converged": True,
+    "ksp_type": "cg",
+    "ksp_rtol": 1e-12,
+    "ksp_max_it": 500,
+    "ksp_converged_reason": "",
+    "ksp_error_if_not_converged": True,
+    "pc_type": "gamg",
+}
+
+
+def _make_problem(domain):
+    """
+    Create solution function, residual form, and BCs for a nonlinear problem
+    (1 + u^2) * inner(grad(u), grad(v)) * dx = f * v * dx  with u = 0 on boundary
+    """
+    V = fem.functionspace(domain, ("Lagrange", 1))
+    u = fem.Function(V)
+    v = ufl.TestFunction(V)
+    x = ufl.SpatialCoordinate(domain)
+
+    f = 10.0 * ufl.exp(-((x[0] - 0.5) ** 2 + (x[1] - 0.5) ** 2) / 0.02)
+    F = (1.0 + u**2) * inner(grad(u + u**2), grad(v)) * dx - f * v * dx
+
+    boundary_facets = mesh.locate_entities_boundary(
+        domain, domain.topology.dim - 1, marker=lambda x: np.ones(x.shape[1], dtype=bool)
+    )
+    dofs = fem.locate_dofs_topological(V, domain.topology.dim - 1, boundary_facets)
+    bc = fem.dirichletbc(PETSc.ScalarType(0.0), dofs, V)
+
+    return u, F, [bc]
+
+
+def _solve_cpu():
+    """Solve the nonlinear problem on the CPU with dolfinx NonlinearProblem"""
+
+    domain = mesh.create_unit_square(MPI.COMM_WORLD, RES, RES)
+    u, F, bcs = _make_problem(domain)
+
+    cpu_problem = NonlinearProblem(
+        F,
+        u,
+        petsc_options_prefix="nl_",
+        bcs=bcs,
+        petsc_options=petsc_options,
+    )
+
+    if MPI.COMM_WORLD.rank == 0:
+        print("_"*75, "\nSolving on CPU\n", flush=True)
+
+    cpu_u = cpu_problem.solve()
+    cpu_iters, cpu_funcevals = (
+        cpu_problem.solver.getIterationNumber(),
+        cpu_problem.solver.getFunctionEvaluations(),
+    )
+
+    return cpu_u, cpu_iters, cpu_funcevals
+
+
+def _solve_gpu():
+    """Solve the nonlinear problem on the CPU with cuda-dolfinx NonlinearProblem"""
+    domain = mesh.create_unit_square(MPI.COMM_WORLD, RES, RES)
+
+    if MPI.COMM_WORLD.size > 1:
+        domain = cufem.ghost_layer_mesh(domain)
+
+    u, F, bcs = _make_problem(domain)
+
+    gpu_problem = cuNonlinearProblem(
+        F,
+        u,
+        petsc_options_prefix="nl_",
+        bcs=bcs,
+        petsc_options=petsc_options,
+    )
+
+    if MPI.COMM_WORLD.rank == 0:
+        print("_"*75, "\nSolving on GPU\n", flush=True)
+
+    gpu_u = gpu_problem.solve()
+    gpu_iters, gpu_funcevals = (
+        gpu_problem.solver.getIterationNumber(),
+        gpu_problem.solver.getFunctionEvaluations(),
+    )
+
+    return gpu_u, gpu_iters, gpu_funcevals
+
+
+def test_nonlinear_problem():
+    """CPU and GPU (single GPU, same mesh) must give the same solution."""
+    cpu_u, cpu_iters, cpu_funcevals = _solve_cpu()
+    gpu_u, gpu_iters, gpu_funcevals = _solve_gpu()
+
+    if MPI.COMM_WORLD.rank == 0:
+        print("\n", "_"*75)
+
+    assert cpu_iters == gpu_iters, (
+        "Number of iterations differs between CPU and GPU"
+    )
+    assert cpu_funcevals == gpu_funcevals, (
+        "Number of function evaluations differs between CPU and GPU"
+    )
+    
+    for norm, label in zip(
+        [PETSc.NormType.NORM_1, PETSc.NormType.NORM_2, PETSc.NormType.NORM_INFINITY],
+        ["L1", "L2", "Linf"]
+    ):
+        cpu_norm = cpu_u.x.petsc_vec.norm(norm)
+        gpu_norm = gpu_u.x.petsc_vec.norm(norm)
+        if MPI.COMM_WORLD.rank == 0:
+            print(f"CPU: {cpu_norm:.16e}\t GPU: {gpu_norm:.16e} ({label} norm)")
+        
+        assert np.isclose(cpu_norm, gpu_norm), (
+            f"{label} norm of solutions differs between CPU and GPU"
+        )
+
+
+if __name__ == "__main__":
+    test_nonlinear_problem()


### PR DESCRIPTION
Adds NonlinearProblem class in `python/cudolfinx/petsc.py`, which is adapted from and directly resembles `dolfinx.fem.petsc.NonlinearProblem`, as well as a demo in `python/examples` making use of this class.

Special attention is necessary to make the SNESLineSearches work: These rely on internal work vectors for both the solution iterate, as well as the residual to be assembled at the solution iterate. This necessitates copies between the assembled vectors and the PETSc work vectors.

Output for said example with `python nonlinear.py --res 50`:

```
750000 elements, 132651 DOFs

  0 SNES Function norm 2.100122195486e-03
    Linear nl_ solve converged due to CONVERGED_RTOL iterations 22
          0 Line search: fty/||y|| = 0.000788004, lambda = 0.5
          1 Line search: fty/||y|| = 0.000393428, lambda = 0.75
          2 Line search: fty/||y|| = 0.00019598, lambda = 0.875
          3 Line search: fty/||y|| = 9.72083e-05, lambda = 0.9375
          4 Line search: fty/||y|| = 4.78093e-05, lambda = 0.96875
          5 Line search: fty/||y|| = 2.31065e-05, lambda = 0.984375
          6 Line search: fty/||y|| = 1.07542e-05, lambda = 0.992188
          7 Line search: fty/||y|| = 4.57785e-06, lambda = 0.996094
          8 Line search: fty/||y|| = 1.48961e-06, lambda = 0.998047
          9 Line search: fty/||y|| = -5.45186e-08, lambda = 0.999023
        Line search: abs(fty)/||y|| = 5.45186e-08 <= atol = 1e-06
  1 SNES Function norm 5.006470670468e-06
    Linear nl_ solve converged due to CONVERGED_RTOL iterations 22
        Line search: sign of fty does not change in step interval, accepting full step
  2 SNES Function norm 3.036569126758e-11
  Nonlinear nl_ solve converged due to CONVERGED_FNORM_ABS iterations 2

elapsed time: 1.336 s (GPU)
```

and for `python nonlinear.py --res 50 --no-cuda`:

```
750000 elements, 132651 DOFs

  0 SNES Function norm 2.100122195486e-03
    Linear nl_ solve converged due to CONVERGED_RTOL iterations 22
          0 Line search: fty/||y|| = 0.000788004, lambda = 0.5
          1 Line search: fty/||y|| = 0.000393428, lambda = 0.75
          2 Line search: fty/||y|| = 0.00019598, lambda = 0.875
          3 Line search: fty/||y|| = 9.72083e-05, lambda = 0.9375
          4 Line search: fty/||y|| = 4.78093e-05, lambda = 0.96875
          5 Line search: fty/||y|| = 2.31065e-05, lambda = 0.984375
          6 Line search: fty/||y|| = 1.07542e-05, lambda = 0.992188
          7 Line search: fty/||y|| = 4.57785e-06, lambda = 0.996094
          8 Line search: fty/||y|| = 1.48961e-06, lambda = 0.998047
          9 Line search: fty/||y|| = -5.45186e-08, lambda = 0.999023
        Line search: abs(fty)/||y|| = 5.45186e-08 <= atol = 1e-06
  1 SNES Function norm 5.006470670469e-06
    Linear nl_ solve converged due to CONVERGED_RTOL iterations 22
        Line search: sign of fty does not change in step interval, accepting full step
  2 SNES Function norm 3.036569125318e-11
  Nonlinear nl_ solve converged due to CONVERGED_FNORM_ABS iterations 2

elapsed time: 8.248 s (CPU)
```